### PR TITLE
Add generic SPARQL endpoint

### DIFF
--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/search/SearchController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/search/SearchController.java
@@ -28,7 +28,6 @@ import nl.dtls.fairdatapoint.api.dto.search.*;
 import nl.dtls.fairdatapoint.database.rdf.repository.exception.MetadataRepositoryException;
 import nl.dtls.fairdatapoint.service.search.SearchService;
 
-import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -36,8 +35,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -84,19 +81,9 @@ public class SearchController {
             consumes = MediaType.TEXT_PLAIN_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE
     )
-    public ResponseEntity<List<Map<String, String>>> sparql(@RequestBody @Valid String query) 
+    public ResponseEntity<Map<String, List<Map<String, Map<String, String>>>>> sparql(@RequestBody @Valid String query) 
       throws MetadataRepositoryException, MalformedQueryException {
-        List<BindingSet> bindingSets = searchService.sparqlSearch(query);
-        List<Map<String, String>> resps = new ArrayList<Map<String, String>>();
-        for (BindingSet set : bindingSets) {
-          HashMap<String, String> bindings = new HashMap<String, String>();
-          for (String name : set.getBindingNames()) {
-            bindings.put(name, set.getValue(name).toString());
-          }
-          resps.add(bindings);
-        }
-
-        return ResponseEntity.ok(resps);
+        return ResponseEntity.ok(Map.of("bindings", searchService.sparqlSearch(query)));
     }
 
     @GetMapping(

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/search/SearchController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/search/SearchController.java
@@ -27,7 +27,6 @@ import jakarta.validation.Valid;
 import nl.dtls.fairdatapoint.api.dto.search.*;
 import nl.dtls.fairdatapoint.database.rdf.repository.exception.MetadataRepositoryException;
 import nl.dtls.fairdatapoint.service.search.SearchService;
-
 import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/search/SearchController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/search/SearchController.java
@@ -76,7 +76,7 @@ public class SearchController {
     public ResponseEntity<List<SearchResultDTO>> searchWithQuery(
             @RequestBody @Valid SearchQueryVariablesDTO reqDto
     ) throws MetadataRepositoryException, MalformedQueryException {
-        return ResponseEntity.ok(searchService.legacySearch(reqDto));
+        return ResponseEntity.ok(searchService.search(reqDto));
     }
 
     @PostMapping(
@@ -84,11 +84,9 @@ public class SearchController {
             consumes = MediaType.TEXT_PLAIN_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE
     )
-    public ResponseEntity<List<Map<String, String>>> searchWithGenericQuery(
-            @RequestBody @Valid String query
-    ) throws MetadataRepositoryException, MalformedQueryException {
-        // return ResponseEntity.ok(searchService.sparql(query));
-        List<BindingSet> bindingSets = searchService.sparql(query);
+    public ResponseEntity<List<Map<String, String>>> sparql(@RequestBody @Valid String query) 
+      throws MetadataRepositoryException, MalformedQueryException {
+        List<BindingSet> bindingSets = searchService.sparqlSearch(query);
         List<Map<String, String>> resps = new ArrayList<Map<String, String>>();
         for (BindingSet set : bindingSets) {
           HashMap<String, String> bindings = new HashMap<String, String>();

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/search/SearchController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/search/SearchController.java
@@ -30,7 +30,6 @@ import nl.dtls.fairdatapoint.service.search.SearchService;
 
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.MalformedQueryException;
-import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -79,13 +78,13 @@ public class SearchController {
 
     @PostMapping(
             path = "/sparql",
-            consumes = MediaType.APPLICATION_JSON_VALUE,
+            consumes = MediaType.TEXT_PLAIN_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE
     )
     public ResponseEntity<List<BindingSet>> searchWithGenericQuery(
-            @RequestBody @Valid SearchQueryDTO query
+            @RequestBody @Valid String query
     ) throws MetadataRepositoryException, MalformedQueryException {
-        return ResponseEntity.ok(searchService.genericSearch(query));
+        return ResponseEntity.ok(searchService.sparql(query));
     }
 
     @GetMapping(

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/search/SearchController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/search/SearchController.java
@@ -78,7 +78,7 @@ public class SearchController {
     }
 
     @PostMapping(
-            path = "/genericQuery",
+            path = "/sparql",
             consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE
     )

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/search/SearchController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/search/SearchController.java
@@ -36,7 +36,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Tag(name = "Search")
 @RestController
@@ -81,10 +84,21 @@ public class SearchController {
             consumes = MediaType.TEXT_PLAIN_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE
     )
-    public ResponseEntity<List<BindingSet>> searchWithGenericQuery(
+    public ResponseEntity<List<Map<String, String>>> searchWithGenericQuery(
             @RequestBody @Valid String query
     ) throws MetadataRepositoryException, MalformedQueryException {
-        return ResponseEntity.ok(searchService.sparql(query));
+        // return ResponseEntity.ok(searchService.sparql(query));
+        List<BindingSet> bindingSets = searchService.sparql(query);
+        List<Map<String, String>> resps = new ArrayList<Map<String, String>>();
+        for (BindingSet set : bindingSets) {
+          HashMap<String, String> bindings = new HashMap<String, String>();
+          for (String name : set.getBindingNames()) {
+            bindings.put(name, set.getValue(name).toString());
+          }
+          resps.add(bindings);
+        }
+
+        return ResponseEntity.ok(resps);
     }
 
     @GetMapping(

--- a/src/main/java/nl/dtls/fairdatapoint/api/controller/search/SearchController.java
+++ b/src/main/java/nl/dtls/fairdatapoint/api/controller/search/SearchController.java
@@ -27,7 +27,10 @@ import jakarta.validation.Valid;
 import nl.dtls.fairdatapoint.api.dto.search.*;
 import nl.dtls.fairdatapoint.database.rdf.repository.exception.MetadataRepositoryException;
 import nl.dtls.fairdatapoint.service.search.SearchService;
+
+import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.MalformedQueryException;
+import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -71,7 +74,18 @@ public class SearchController {
     public ResponseEntity<List<SearchResultDTO>> searchWithQuery(
             @RequestBody @Valid SearchQueryVariablesDTO reqDto
     ) throws MetadataRepositoryException, MalformedQueryException {
-        return ResponseEntity.ok(searchService.search(reqDto));
+        return ResponseEntity.ok(searchService.legacySearch(reqDto));
+    }
+
+    @PostMapping(
+            path = "/genericQuery",
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<List<BindingSet>> searchWithGenericQuery(
+            @RequestBody @Valid SearchQueryDTO query
+    ) throws MetadataRepositoryException, MalformedQueryException {
+        return ResponseEntity.ok(searchService.genericSearch(query));
     }
 
     @GetMapping(

--- a/src/main/java/nl/dtls/fairdatapoint/database/rdf/repository/common/AbstractMetadataRepository.java
+++ b/src/main/java/nl/dtls/fairdatapoint/database/rdf/repository/common/AbstractMetadataRepository.java
@@ -34,6 +34,7 @@ import org.eclipse.rdf4j.model.*;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
@@ -43,6 +44,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Set;
 import java.util.Map;
 import java.util.Optional;
 
@@ -121,6 +123,10 @@ public abstract class AbstractMetadataRepository {
                 .map(item -> toSearchResult(item, false))
                 .toList();
     }
+
+//    private GenericSearchResult toGenericSearchResult(BindingSet item) {
+//        Set<String> bindingNames = item.getBindingNames();
+//    }
 
     private SearchResult toSearchResult(BindingSet item, boolean withRelation) {
         SearchResultRelation relation = null;

--- a/src/main/java/nl/dtls/fairdatapoint/database/rdf/repository/common/AbstractMetadataRepository.java
+++ b/src/main/java/nl/dtls/fairdatapoint/database/rdf/repository/common/AbstractMetadataRepository.java
@@ -34,7 +34,6 @@ import org.eclipse.rdf4j.model.*;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.query.TupleQuery;
-import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
@@ -44,7 +43,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Set;
 import java.util.Map;
 import java.util.Optional;
 
@@ -123,10 +121,6 @@ public abstract class AbstractMetadataRepository {
                 .map(item -> toSearchResult(item, false))
                 .toList();
     }
-
-//    private GenericSearchResult toGenericSearchResult(BindingSet item) {
-//        Set<String> bindingNames = item.getBindingNames();
-//    }
 
     private SearchResult toSearchResult(BindingSet item, boolean withRelation) {
         SearchResultRelation relation = null;

--- a/src/main/java/nl/dtls/fairdatapoint/database/rdf/repository/common/MetadataRepository.java
+++ b/src/main/java/nl/dtls/fairdatapoint/database/rdf/repository/common/MetadataRepository.java
@@ -69,6 +69,6 @@ public interface MetadataRepository {
                                     Map<String, Value> bindings)
             throws MetadataRepositoryException;
 
-    List<BindingSet> runSparqlQuery(String queryName)
+    List<BindingSet> runSparqlQuery(String query)
             throws MetadataRepositoryException;
 }

--- a/src/main/java/nl/dtls/fairdatapoint/database/rdf/repository/common/MetadataRepository.java
+++ b/src/main/java/nl/dtls/fairdatapoint/database/rdf/repository/common/MetadataRepository.java
@@ -32,6 +32,7 @@ import nl.dtls.fairdatapoint.entity.search.SearchFilterValue;
 import nl.dtls.fairdatapoint.entity.search.SearchResult;
 import org.eclipse.rdf4j.model.*;
 import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.TupleQueryResult;
 
 import java.util.List;
 import java.util.Map;
@@ -66,5 +67,8 @@ public interface MetadataRepository {
 
     List<BindingSet> runSparqlQuery(String queryName, Class repositoryType,
                                     Map<String, Value> bindings)
+            throws MetadataRepositoryException;
+
+    List<BindingSet> runSparqlQuery(String queryName)
             throws MetadataRepositoryException;
 }

--- a/src/main/java/nl/dtls/fairdatapoint/service/search/SearchMapper.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/search/SearchMapper.java
@@ -27,11 +27,22 @@ import nl.dtls.fairdatapoint.entity.search.SearchFilterValue;
 import nl.dtls.fairdatapoint.entity.search.SearchResult;
 import nl.dtls.fairdatapoint.entity.settings.SettingsSearchFilter;
 import nl.dtls.fairdatapoint.entity.settings.SettingsSearchFilterItem;
+
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.util.Literals;
+import org.eclipse.rdf4j.model.vocabulary.XSD;
+import org.eclipse.rdf4j.query.BindingSet;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
 import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Component
 public class SearchMapper {
@@ -101,5 +112,46 @@ public class SearchMapper {
                 "graphPattern", reqDto.getGraphPattern() + FRAGMENT_SUFFIX,
                 "ordering", reqDto.getOrdering() + FRAGMENT_SUFFIX
         );
+  }
+
+  public List<Map<String, Map<String, String>>> toBindingList(List<BindingSet> sets) {
+    return sets.stream().map(set -> {
+      return set.getBindingNames()
+          .stream()
+          .collect(Collectors.toMap(Function.identity(), name -> {
+            return renderValue(set.getValue(name));
+          }));
+    }).toList();
+  }
+
+  private Map<String, String> renderValue(Value value) {
+    if (value instanceof IRI) {
+      return Map.of(
+          "type", "uri",
+          "value", ((IRI) value).toString());
+    } else if (value instanceof BNode) {
+      return Map.of(
+          "type", "bnode",
+          "value", ((BNode) value).getID());
+    } else if (value instanceof Literal) {
+      final Literal lit = (Literal) value;
+      HashMap<String, String> result = new HashMap<>();
+      result.put("type", "literal");
+      result.put("value", lit.getLabel());
+
+      if (Literals.isLanguageLiteral(lit)) {
+        result.put("xml:lang", lit.getLanguage().orElse(null));
+      } else {
+        final IRI datatype = lit.getDatatype();
+        final boolean ignoreDatatype = datatype.equals(XSD.STRING);
+        if (!ignoreDatatype) {
+          result.put("datatype", datatype.stringValue());
+        }
+      }
+
+      return result;
+    } else {
+      return Map.of("value", value.toString());
     }
+  }
 }

--- a/src/main/java/nl/dtls/fairdatapoint/service/search/SearchService.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/search/SearchService.java
@@ -38,7 +38,10 @@ import nl.dtls.fairdatapoint.service.metadata.state.MetadataStateService;
 import nl.dtls.fairdatapoint.service.settings.SettingsService;
 import org.apache.commons.lang.text.StrSubstitutor;
 import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.query.Binding;
+import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.MalformedQueryException;
+import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.query.parser.sparql.SPARQLParser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -84,7 +87,7 @@ public class SearchService {
     public List<SearchResultDTO> search(
             SearchSavedQueryDTO searchSavedQueryDTO
     ) throws MetadataRepositoryException {
-        return search(searchSavedQueryDTO.getVariables());
+        return legacySearch(searchSavedQueryDTO.getVariables());
     }
 
     public List<SearchResultDTO> search(SearchQueryDTO reqDto) throws MetadataRepositoryException {
@@ -92,17 +95,29 @@ public class SearchService {
         return processSearchResults(results);
     }
 
-    public List<SearchResultDTO> search(
-            SearchQueryVariablesDTO reqDto
+    private void verifyQuery(
+            String query
     ) throws MetadataRepositoryException, MalformedQueryException {
-        // Compose query
-        final String query = composeQuery(reqDto);
-        // Verify query
         final SPARQLParser parser = new SPARQLParser();
         parser.parseQuery(query, persistentUrl);
-        // Get and process results for query
+    }
+
+    public List<SearchResultDTO> legacySearch(
+            SearchQueryVariablesDTO reqDto
+    ) throws MetadataRepositoryException, MalformedQueryException {
+        final String query = composeQuery(reqDto);
+        verifyQuery(query);
         final List<SearchResult> results = metadataRepository.findBySparqlQuery(query);
         return processSearchResults(results);
+    }
+
+    public List<BindingSet> genericSearch(
+            SearchQueryDTO searchQuery
+    ) throws MetadataRepositoryException, MalformedQueryException {
+        final String query = searchQuery.getQuery();
+        verifyQuery(query);
+        final List<BindingSet> results = metadataRepository.runSparqlQuery(query);
+        return results;
     }
 
     public SearchQueryTemplateDTO getSearchQueryTemplate() {

--- a/src/main/java/nl/dtls/fairdatapoint/service/search/SearchService.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/search/SearchService.java
@@ -85,7 +85,7 @@ public class SearchService {
     public List<SearchResultDTO> search(
             SearchSavedQueryDTO searchSavedQueryDTO
     ) throws MetadataRepositoryException {
-        return legacySearch(searchSavedQueryDTO.getVariables());
+        return search(searchSavedQueryDTO.getVariables());
     }
 
     public List<SearchResultDTO> search(SearchQueryDTO reqDto) throws MetadataRepositoryException {
@@ -100,7 +100,7 @@ public class SearchService {
         parser.parseQuery(query, persistentUrl);
     }
 
-    public List<SearchResultDTO> legacySearch(
+    public List<SearchResultDTO> search(
             SearchQueryVariablesDTO reqDto
     ) throws MetadataRepositoryException, MalformedQueryException {
         final String query = composeQuery(reqDto);
@@ -109,11 +109,9 @@ public class SearchService {
         return processSearchResults(results);
     }
 
-    public List<BindingSet> sparql(String query) throws MetadataRepositoryException, MalformedQueryException {
+    public List<BindingSet> sparqlSearch(String query) throws MetadataRepositoryException, MalformedQueryException {
         verifyQuery(query);
-        final List<BindingSet> results = metadataRepository.runSparqlQuery(query);
-        System.out.println(results);
-        return results;
+        return metadataRepository.runSparqlQuery(query);
     }
 
     public SearchQueryTemplateDTO getSearchQueryTemplate() {

--- a/src/main/java/nl/dtls/fairdatapoint/service/search/SearchService.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/search/SearchService.java
@@ -38,10 +38,8 @@ import nl.dtls.fairdatapoint.service.metadata.state.MetadataStateService;
 import nl.dtls.fairdatapoint.service.settings.SettingsService;
 import org.apache.commons.lang.text.StrSubstitutor;
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.query.Binding;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.MalformedQueryException;
-import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.query.parser.sparql.SPARQLParser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -111,12 +109,10 @@ public class SearchService {
         return processSearchResults(results);
     }
 
-    public List<BindingSet> genericSearch(
-            SearchQueryDTO searchQuery
-    ) throws MetadataRepositoryException, MalformedQueryException {
-        final String query = searchQuery.getQuery();
+    public List<BindingSet> sparql(String query) throws MetadataRepositoryException, MalformedQueryException {
         verifyQuery(query);
         final List<BindingSet> results = metadataRepository.runSparqlQuery(query);
+        System.out.println(results);
         return results;
     }
 

--- a/src/main/java/nl/dtls/fairdatapoint/service/search/SearchService.java
+++ b/src/main/java/nl/dtls/fairdatapoint/service/search/SearchService.java
@@ -109,9 +109,10 @@ public class SearchService {
         return processSearchResults(results);
     }
 
-    public List<BindingSet> sparqlSearch(String query) throws MetadataRepositoryException, MalformedQueryException {
+    public List<Map<String, Map<String, String>>> sparqlSearch(String query) throws MetadataRepositoryException, MalformedQueryException {
         verifyQuery(query);
-        return metadataRepository.runSparqlQuery(query);
+        List<BindingSet> sets = metadataRepository.runSparqlQuery(query);
+        return searchMapper.toBindingList(sets);
     }
 
     public SearchQueryTemplateDTO getSearchQueryTemplate() {


### PR DESCRIPTION
Adds endpoint `POST search/sparql` which receives SPARQL tuple queries as plain text., and returns results as `JSON`.

If the service is running locally, the endpoint can be tested at http://localhost:8080/swagger-ui/index.html#/Search/sparql

`select ?s ?p ?o where {?s ?p ?o}`
should result in an answer like
```json
{
  "bindings": [
    {
      "p": {
        "value": "http://www.w3.org/ns/dcat#version",
        "type": "uri"
      },
      "s": {
        "value": "http://localhost:8080",
        "type": "uri"
      },
      "o": {
        "datatype": "http://www.w3.org/2001/XMLSchema#float",
        "type": "literal",
        "value": "1.0"
      }
    }
  ]
}
```
